### PR TITLE
chore: upgrade mkdocs

### DIFF
--- a/bin/build-docs.sh
+++ b/bin/build-docs.sh
@@ -11,5 +11,5 @@ docker run --rm -it \
   -e GOOGLE_ANALYTICS_KEY \
   -v "${PWD}/docs-bosh:/docs" \
   -v "${PWD}/templates/docs:/site" \
-  squidfunk/mkdocs-material:2.7.2 \
+  squidfunk/mkdocs-material:9.7.6 \
   build --site-dir=/site

--- a/controllers/releases_controller.go
+++ b/controllers/releases_controller.go
@@ -77,9 +77,12 @@ func (c ReleasesController) Index(r martrend.Render) {
 		return
 	}
 
+	rootnav := bhrelui.Navigation()
+	rootnav.Children()[0].Activate("/releases")
+
 	page := releasesControllerIndexPage{
 		UniqueSources: bhrelui.NewUniqueSources(sources),
-		NavPrimary:    bhrelui.Navigation(),
+		NavPrimary:    rootnav,
 	}
 
 	r.HTML(200, c.indexTmpl, page)

--- a/controllers/releases_controller.go
+++ b/controllers/releases_controller.go
@@ -78,7 +78,7 @@ func (c ReleasesController) Index(r martrend.Render) {
 	}
 
 	rootnav := bhrelui.Navigation()
-	rootnav.Children()[0].Activate("/releases")
+	rootnav.Activate("/releases")
 
 	page := releasesControllerIndexPage{
 		UniqueSources: bhrelui.NewUniqueSources(sources),

--- a/main/main.go
+++ b/main/main.go
@@ -148,10 +148,19 @@ func configureAssets(m *mart.ClassicMartini, analyticsConfig AnalyticsConfig, lo
 
 	themeJavascriptApplication, err := filepath.Glob("templates/docs/assets/javascripts/bundle.*.min.js")
 	if err != nil {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find bnudle.*.min.js: %v", err))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find bundle.*.min.js: %v", err))
 		os.Exit(1)
 	} else if len(themeJavascriptApplication) != 1 {
 		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one bundle.*.min.js: found %d", len(themeJavascriptApplication)))
+		os.Exit(1)
+	}
+
+	themeJavascriptSearch, err := filepath.Glob("templates/docs/assets/javascripts/workers/search.*.min.js")
+	if err != nil {
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find search.*.min.js: %v", err))
+		os.Exit(1)
+	} else if len(themeJavascriptApplication) != 1 {
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one search.*.min.js: found %d", len(themeJavascriptApplication)))
 		os.Exit(1)
 	}
 
@@ -185,6 +194,9 @@ func configureAssets(m *mart.ClassicMartini, analyticsConfig AnalyticsConfig, lo
 		},
 		"themeJavascriptApplication": func() string {
 			return fmt.Sprintf("/docs/assets/javascripts/%s", path.Base(themeJavascriptApplication[0]))
+		},
+		"themeJavascriptSearch": func() string {
+			return fmt.Sprintf("/docs/assets/javascripts/workers/%s", path.Base(themeJavascriptSearch[0]))
 		},
 		"themeImageFavicon": func() string {
 			return fmt.Sprintf("/docs/assets/images/%s", path.Base(themeImageFavicon[0]))

--- a/main/main.go
+++ b/main/main.go
@@ -119,21 +119,21 @@ func runControllers(controllerFactory bhctrls.Factory, analyticsConfig Analytics
 }
 
 func configureAssets(m *mart.ClassicMartini, analyticsConfig AnalyticsConfig, logger boshlog.Logger) {
-	themeStylesheetApplication, err := filepath.Glob("templates/docs/assets/stylesheets/application.*.css")
+	themeStylesheetApplication, err := filepath.Glob("templates/docs/assets/stylesheets/main.*.min.css")
 	if err != nil {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find application.*.css: %v", err))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find main.*.min.css: %v", err))
 		os.Exit(1)
 	} else if len(themeStylesheetApplication) != 1 {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one application.*.css: found %d", len(themeStylesheetApplication)))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one main.*.min.css: found %d", len(themeStylesheetApplication)))
 		os.Exit(1)
 	}
 
-	themeStylesheetApplicationPalette, err := filepath.Glob("templates/docs/assets/stylesheets/application-palette.*.css")
+	themeStylesheetApplicationPalette, err := filepath.Glob("templates/docs/assets/stylesheets/palette.*.min.css")
 	if err != nil {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find application-palette.*.css: %v", err))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find palette.*.min.css: %v", err))
 		os.Exit(1)
 	} else if len(themeStylesheetApplicationPalette) != 1 {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one application-palette.*.css: found %d", len(themeStylesheetApplicationPalette)))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one palette.*.min.css: found %d", len(themeStylesheetApplicationPalette)))
 		os.Exit(1)
 	}
 
@@ -146,21 +146,12 @@ func configureAssets(m *mart.ClassicMartini, analyticsConfig AnalyticsConfig, lo
 		os.Exit(1)
 	}
 
-	themeJavascriptModernizr, err := filepath.Glob("templates/docs/assets/javascripts/modernizr.*.js")
+	themeJavascriptApplication, err := filepath.Glob("templates/docs/assets/javascripts/bundle.*.min.js")
 	if err != nil {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find modernizr.*.js: %v", err))
-		os.Exit(1)
-	} else if len(themeJavascriptModernizr) != 1 {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one modernizr.*.js: found %d", len(themeJavascriptModernizr)))
-		os.Exit(1)
-	}
-
-	themeJavascriptApplication, err := filepath.Glob("templates/docs/assets/javascripts/application.*.js")
-	if err != nil {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find application.*.js: %v", err))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find bnudle.*.min.js: %v", err))
 		os.Exit(1)
 	} else if len(themeJavascriptApplication) != 1 {
-		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one application.*.js: found %d", len(themeJavascriptApplication)))
+		logger.Error(mainLogTag, fmt.Sprintf("Failed to find exactly one bundle.*.min.js: found %d", len(themeJavascriptApplication)))
 		os.Exit(1)
 	}
 
@@ -191,9 +182,6 @@ func configureAssets(m *mart.ClassicMartini, analyticsConfig AnalyticsConfig, lo
 		},
 		"themeStylesheetExtra": func() string {
 			return fmt.Sprintf("/docs/assets/stylesheets/%s", path.Base(themeStylesheetExtra[0]))
-		},
-		"themeJavascriptModernizr": func() string {
-			return fmt.Sprintf("/docs/assets/javascripts/%s", path.Base(themeJavascriptModernizr[0]))
 		},
 		"themeJavascriptApplication": func() string {
 			return fmt.Sprintf("/docs/assets/javascripts/%s", path.Base(themeJavascriptApplication[0]))

--- a/templates/error.tmpl
+++ b/templates/error.tmpl
@@ -1,5 +1,5 @@
 {{ template "shared/_nav_tabs" "Error" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     <div class="md-content">
       <article class="md-content__inner md-typeset">

--- a/templates/jobs/_nav_secondary.tmpl
+++ b/templates/jobs/_nav_secondary.tmpl
@@ -1,4 +1,4 @@
-<div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+<div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
   <div class="md-sidebar__scrollwrap">
     <div class="md-sidebar__inner">
       <nav class="md-nav md-nav--secondary">

--- a/templates/jobs/_properties.tmpl
+++ b/templates/jobs/_properties.tmpl
@@ -9,7 +9,7 @@
     <dl>
       {{ if .Property.HasDefault }}
         <dt>Default</dt>
-        <dd><div class="codehilite"><pre>{{ .DefaultAsYAML }}</pre></div></dd>
+        <dd><div class="highlight"><pre><code>{{ .DefaultAsYAML }}</code></pre></div></dd>
       {{ end }}
       {{ if .Property.Examples }}
         <dt>Example</dt>

--- a/templates/jobs/show.tmpl
+++ b/templates/jobs/show.tmpl
@@ -1,5 +1,5 @@
 {{ template "shared/_nav_tabs" "Releases" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .Release.NavPrimary }}
     {{ template "jobs/_nav_secondary" . }}

--- a/templates/jobs/show.tmpl
+++ b/templates/jobs/show.tmpl
@@ -6,7 +6,7 @@
     <div class="md-content">
       <article class="md-content__inner md-typeset">
         <div class="bosh-schema">
-          <h1>{{ .Name }} job <small>from {{ .Release.Name }}/{{ .Release.Version }}</small></h1>
+          <h1 id="bosh-content-start">{{ .Name }} job <small>from {{ .Release.Name }}/{{ .Release.Version }}</small></h1>
 
           {{ if .Description }}
             <p>{{ .Description }}</p>

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -171,21 +171,6 @@
       {{ yield }}
       
       <footer class="md-footer">
-        <nav class="md-footer__inner md-grid" aria-label="Footer">
-          <a href="problems/" class="md-footer__link md-footer__link--next" aria-label="Next: Project Goals">
-            <div class="md-footer__title">
-              <span class="md-footer__direction">
-                Next
-              </span>
-              <div class="md-ellipsis">
-                Project Goals
-              </div>
-            </div>
-            <div class="md-footer__button md-icon">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 11v2h12l-5.5 5.5 1.42 1.42L19.84 12l-7.92-7.92L10.5 5.5 16 11z"/></svg>
-            </div>
-          </a>
-        </nav>
         <div class="md-footer-meta md-typeset">
           <div class="md-footer-meta__inner md-grid">
             <div class="md-copyright">

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -28,7 +28,7 @@
     <div data-md-component="skip">
       
         
-        <a href="#welcome-to" class="md-skip">
+        <a href="#bosh-content-start" class="md-skip">
           Skip to content
         </a>
       
@@ -44,7 +44,7 @@
   <nav class="md-header__inner md-grid" aria-label="Header">
     <a href="." title="Cloud Foundry BOSH" class="md-header__button md-logo" aria-label="Cloud Foundry BOSH" data-md-component="logo">
       
-  <img src="/docs/assets/images/logo.d93e7da69dbf.png" alt="logo">
+  <img src="{{ themeImageLogo }}" alt="logo">
 
     </a>
     <label class="md-header__button md-icon" for="__drawer">
@@ -197,8 +197,8 @@
     <div class="md-dialog" data-md-component="dialog">
       <div class="md-dialog__inner md-typeset"></div>
     </div>
-    <script id="__config" type="application/json">{"annotate": null, "base": "/docs/", "features": ["content.action.edit", "content.code.copy", "navigation.tabs", "navigation.footer"], "search": "/docs/assets/javascripts/workers/search.2c215733.min.js", "tags": null, "translations": {"clipboard.copied": "Copied to clipboard", "clipboard.copy": "Copy to clipboard", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.placeholder": "Type to start searching", "search.result.term.missing": "Missing", "select.version": "Select version"}, "version": null}</script>
+    <script id="__config" type="application/json">{"annotate": null, "base": "/docs/", "features": ["content.action.edit", "content.code.copy", "navigation.tabs", "navigation.footer"], "search": "{{ themeJavascriptSearch }}", "tags": null, "translations": {"clipboard.copied": "Copied to clipboard", "clipboard.copy": "Copy to clipboard", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.placeholder": "Type to start searching", "search.result.term.missing": "Missing", "select.version": "Select version"}, "version": null}</script>
     
-    <script src="/docs/assets/javascripts/bundle.79ae519e.min.js"></script>
+    <script src="{{ themeJavascriptApplication }}"></script>
   </body>
 </html>

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -1,235 +1,219 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width,initial-scale=1">
-      <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <link rel="icon" href="{{ themeImageFavicon }}">
+    <meta name="generator" content="bosh-io/web, mkdocs-1.6.1, mkdocs-material-9.7.6">
+    <title>Cloud Foundry BOSH</title><!-- TODO .PageTitle -->
 
+    <link rel="stylesheet" href="{{ themeStylesheetApplication }}">
+    <link rel="stylesheet" href="{{ themeStylesheetApplicationPalette }}">
 
-        <!-- <link rel="canonical" href="https://bosh.io/docs/"> -->
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i%7CRoboto+Mono:400,400i,700,700i&amp;display=fallback">
+    <style>body,input{font-family:"Roboto","Helvetica Neue",Helvetica,Arial,sans-serif}code,kbd,pre{font-family:"Roboto Mono","Courier New",Courier,monospace}</style>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="{{ themeStylesheetExtra }}">
 
-
-
-        <meta name="lang:clipboard.copy" content="Copy to clipboard">
-
-        <meta name="lang:clipboard.copied" content="Copied to clipboard">
-
-        <meta name="lang:search.language" content="en">
-
-        <meta name="lang:search.pipeline.stopwords" content="True">
-
-        <meta name="lang:search.pipeline.trimmer" content="True">
-
-        <meta name="lang:search.result.none" content="No matching documents">
-
-        <meta name="lang:search.result.one" content="1 matching document">
-
-        <meta name="lang:search.result.other" content="# matching documents">
-
-        <meta name="lang:search.tokenizer" content="[\s\-]+">
-
-      <link rel="shortcut icon" href="{{ themeImageFavicon }}">
-      <meta name="generator" content="bosh-io/web, mkdocs-0.17.3, mkdocs-material-2.7.1">
-
-
-
-        <title>Cloud Foundry BOSH</title><!-- TODO .PageTitle -->
-
-
-
-      <link rel="stylesheet" href="{{ themeStylesheetApplication }}">
-
-        <link rel="stylesheet" href="{{ themeStylesheetApplicationPalette }}">
-
-
-
-      <script src="{{ themeJavascriptModernizr }}"></script>
-
-
-      <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
-
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700|Roboto+Mono">
-        <style>body,input{font-family:"Roboto","Helvetica Neue",Helvetica,Arial,sans-serif}code,kbd,pre{font-family:"Roboto Mono","Courier New",Courier,monospace}</style>
-
-      <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-
-
-      <link rel="stylesheet" href="{{ themeStylesheetExtra }}">
-
-
+    <script>__md_scope=new URL(".",location),__md_hash=e=>[...e].reduce(((e,_)=>(e<<5)-e+_.charCodeAt(0)),0),__md_get=(e,_=localStorage,t=__md_scope)=>JSON.parse(_.getItem(t.pathname+"."+e)),__md_set=(e,_,t=localStorage,a=__md_scope)=>{try{t.setItem(a.pathname+"."+e,JSON.stringify(_))}catch(e){}}</script>
   </head>
-
-
-    <body dir="ltr" data-md-color-primary="blue" data-md-color-accent="blue">
-
-    <svg class="md-svg">
-      <defs>
-
-
-          <svg xmlns="http://www.w3.org/2000/svg" width="416" height="448"
-    viewBox="0 0 416 448" id="github">
-  <path fill="currentColor" d="M160 304q0 10-3.125 20.5t-10.75 19-18.125
-        8.5-18.125-8.5-10.75-19-3.125-20.5 3.125-20.5 10.75-19 18.125-8.5
-        18.125 8.5 10.75 19 3.125 20.5zM320 304q0 10-3.125 20.5t-10.75
-        19-18.125 8.5-18.125-8.5-10.75-19-3.125-20.5 3.125-20.5 10.75-19
-        18.125-8.5 18.125 8.5 10.75 19 3.125 20.5zM360
-        304q0-30-17.25-51t-46.75-21q-10.25 0-48.75 5.25-17.75 2.75-39.25
-        2.75t-39.25-2.75q-38-5.25-48.75-5.25-29.5 0-46.75 21t-17.25 51q0 22 8
-        38.375t20.25 25.75 30.5 15 35 7.375 37.25 1.75h42q20.5 0
-        37.25-1.75t35-7.375 30.5-15 20.25-25.75 8-38.375zM416 260q0 51.75-15.25
-        82.75-9.5 19.25-26.375 33.25t-35.25 21.5-42.5 11.875-42.875 5.5-41.75
-        1.125q-19.5 0-35.5-0.75t-36.875-3.125-38.125-7.5-34.25-12.875-30.25-20.25-21.5-28.75q-15.5-30.75-15.5-82.75
-        0-59.25 34-99-6.75-20.5-6.75-42.5 0-29 12.75-54.5 27 0 47.5 9.875t47.25
-        30.875q36.75-8.75 77.25-8.75 37 0 70 8 26.25-20.5
-        46.75-30.25t47.25-9.75q12.75 25.5 12.75 54.5 0 21.75-6.75 42 34 40 34
-        99.5z" />
-</svg>
-
-      </defs>
-    </svg>
-    <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="drawer" autocomplete="off">
-    <input class="md-toggle" data-md-toggle="search" type="checkbox" id="search" autocomplete="off">
-    <label class="md-overlay" data-md-component="overlay" for="drawer"></label>
-
-      <a href="#downloads" tabindex="1" class="md-skip">
-        Skip to content
-      </a>
-
-
-      <header class="md-header" data-md-component="header">
-  <nav class="md-header-nav md-grid">
-    <div class="md-flex">
-      <div class="md-flex__cell md-flex__cell--shrink">
-        <a href="/docs/" title="Cloud Foundry BOSH" class="md-header-nav__button md-logo">
-
-            <img src="{{ themeImageLogo }}" width="24" height="24">
-
+  
+  <body dir="ltr" data-md-color-scheme="default" data-md-color-primary="blue" data-md-color-accent="indigo">
+ 
+    <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
+    <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
+    <label class="md-overlay" for="__drawer"></label>
+    <div data-md-component="skip">
+      
+        
+        <a href="#welcome-to" class="md-skip">
+          Skip to content
         </a>
-      </div>
-      <div class="md-flex__cell md-flex__cell--shrink">
-        <label class="md-icon md-icon--menu md-header-nav__button" for="drawer"></label>
-      </div>
-      <div class="md-flex__cell md-flex__cell--stretch">
-        <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
+      
+    </div>
+    <div data-md-component="announce">
+      
+    </div>
+    
+    
+      
 
+<header class="md-header" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="Header">
+    <a href="." title="Cloud Foundry BOSH" class="md-header__button md-logo" aria-label="Cloud Foundry BOSH" data-md-component="logo">
+      
+  <img src="/docs/assets/images/logo.d93e7da69dbf.png" alt="logo">
 
-              <span class="md-header-nav__topic">
-                Cloud Foundry BOSH
-              </span>
-              <span class="md-header-nav__topic">
-                Cloud Foundry BOSH <!-- TODO .PageTitle -->
-              </span>
-
-
+    </a>
+    <label class="md-header__button md-icon" for="__drawer">
+      
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 6h18v2H3zm0 5h18v2H3zm0 5h18v2H3z"></path></svg>
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            Cloud Foundry BOSH
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            
+              Welcome
+            
+          </span>
         </div>
       </div>
-      <div class="md-flex__cell md-flex__cell--shrink">
-
-
-            <label class="md-icon md-icon--search md-header-nav__button" for="search"></label>
-
-<div class="md-search" data-md-component="search" role="dialog">
-  <label class="md-search__overlay" for="search"></label>
+    </div>
+    
+      
+        <form class="md-header__option" data-md-component="palette">
+  
+    
+    
+    
+    <input class="md-option" data-md-color-media="(prefers-color-scheme)" data-md-color-scheme="default" data-md-color-primary="blue" data-md-color-accent="indigo" aria-label="Switch to light mode" type="radio" name="__palette" id="__palette_0">
+    
+      <label class="md-header__button md-icon" title="Switch to light mode" for="__palette_1" hidden="">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m14.3 16-.7-2h-3.2l-.7 2H7.8L11 7h2l3.2 9zM20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12zm-9.15 3.96h2.3L12 9z"></path></svg>
+      </label>
+    
+  
+    
+    
+    
+    <input class="md-option" data-md-color-media="(prefers-color-scheme: light)" data-md-color-scheme="default" data-md-color-primary="blue" data-md-color-accent="indigo" aria-label="Switch to dark mode" type="radio" name="__palette" id="__palette_1">
+    
+      <label class="md-header__button md-icon" title="Switch to dark mode" for="__palette_2" hidden="">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4m0 10a6 6 0 0 1-6-6 6 6 0 0 1 6-6 6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12z"></path></svg>
+      </label>
+    
+  
+    
+    
+    
+    <input class="md-option" data-md-color-media="(prefers-color-scheme: dark)" data-md-color-scheme="slate" data-md-color-primary="blue" data-md-color-accent="indigo" aria-label="Switch to light mode" type="radio" name="__palette" id="__palette_2">
+    
+      <label class="md-header__button md-icon" title="Switch to light mode" for="__palette_0" hidden="">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 18c-.89 0-1.74-.2-2.5-.55C11.56 16.5 13 14.42 13 12s-1.44-4.5-3.5-5.45C10.26 6.2 11.11 6 12 6a6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12z"></path></svg>
+      </label>
+    
+  
+</form>
+      
+    
+    
+      <script>var palette=__md_get("__palette");if(palette&&palette.color){if("(prefers-color-scheme)"===palette.color.media){var media=matchMedia("(prefers-color-scheme: light)"),input=document.querySelector(media.matches?"[data-md-color-media='(prefers-color-scheme: light)']":"[data-md-color-media='(prefers-color-scheme: dark)']");palette.color.media=input.getAttribute("data-md-color-media"),palette.color.scheme=input.getAttribute("data-md-color-scheme"),palette.color.primary=input.getAttribute("data-md-color-primary"),palette.color.accent=input.getAttribute("data-md-color-accent")}for(var[key,value]of Object.entries(palette.color))document.body.setAttribute("data-md-color-"+key,value)}</script>
+    
+    
+    
+      
+      
+        <label class="md-header__button md-icon" for="__search">
+          
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5-1.5 1.5-5-5v-.79l-.27-.27A6.52 6.52 0 0 1 9.5 16 6.5 6.5 0 0 1 3 9.5 6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14 14 12 14 9.5 12 5 9.5 5"></path></svg>
+        </label>
+        <div class="md-search" data-md-component="search" role="dialog">
+  <label class="md-search__overlay" for="__search"></label>
   <div class="md-search__inner" role="search">
     <form class="md-search__form" name="search">
-      <input type="text" class="md-search__input" name="query" placeholder="Search" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="query" data-md-state="active">
-      <label class="md-icon md-search__icon" for="search"></label>
-      <button type="reset" class="md-icon md-search__icon" data-md-component="reset" tabindex="-1">
-        &#xE5CD;
-      </button>
+      <input type="text" class="md-search__input" name="query" aria-label="Search" placeholder="Search" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="search-query" required="">
+      <label class="md-search__icon md-icon" for="__search">
+        
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5-1.5 1.5-5-5v-.79l-.27-.27A6.52 6.52 0 0 1 9.5 16 6.5 6.5 0 0 1 3 9.5 6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14 14 12 14 9.5 12 5 9.5 5"></path></svg>
+        
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11v2H8l5.5 5.5-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5 8 11z"></path></svg>
+      </label>
+      <nav class="md-search__options" aria-label="Search">
+        
+        <button type="reset" class="md-search__icon md-icon" title="Clear" aria-label="Clear" tabindex="-1">
+          
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></svg>
+        </button>
+      </nav>
+      
     </form>
     <div class="md-search__output">
-      <div class="md-search__scrollwrap" data-md-scrollfix>
-        <div class="md-search-result" data-md-component="result">
+      <div class="md-search__scrollwrap" tabindex="0" data-md-scrollfix="">
+        <div class="md-search-result" data-md-component="search-result">
           <div class="md-search-result__meta">
-            Type to start searching
+            Initializing search
           </div>
-          <ol class="md-search-result__list"></ol>
+          <ol class="md-search-result__list" role="presentation"></ol>
         </div>
       </div>
     </div>
   </div>
 </div>
-
-
+      
+    
+    
+      <div class="md-header__source">
+        <a href="https://github.com/cloudfoundry/bosh" title="Go to repository" class="md-source" data-md-component="source">
+  <div class="md-source__icon md-icon">
+    
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M439.6 236.1 244 40.5c-5.4-5.5-12.8-8.5-20.4-8.5s-15 3-20.4 8.4L162.5 81l51.5 51.5c27.1-9.1 52.7 16.8 43.4 43.7l49.7 49.7c34.2-11.8 61.2 31 35.5 56.7-26.5 26.5-70.2-2.9-56-37.3L240.3 199v121.9c25.3 12.5 22.3 41.8 9.1 55-6.4 6.4-15.2 10.1-24.3 10.1s-17.8-3.6-24.3-10.1c-17.6-17.6-11.1-46.9 11.2-56v-123c-20.8-8.5-24.6-30.7-18.6-45L142.6 101 8.5 235.1C3 240.6 0 247.9 0 255.5s3 15 8.5 20.4l195.6 195.7c5.4 5.4 12.7 8.4 20.4 8.4s15-3 20.4-8.4l194.7-194.7c5.4-5.4 8.4-12.8 8.4-20.4s-3-15-8.4-20.4"></path></svg>
+  </div>
+  <div class="md-source__repository">
+    cloudfoundry/bosh
+  </div>
+</a>
       </div>
-
-        <div class="md-flex__cell md-flex__cell--shrink">
-          <div class="md-header-nav__source">
-
-
-
-
-
-
-  <a href="https://github.com/cloudfoundry/bosh" title="Go to repository" class="md-source" data-md-source="github">
-
-      <div class="md-source__icon">
-        <svg viewBox="0 0 24 24" width="24" height="24">
-          <use xlink:href="#github" width="24" height="24"></use>
-        </svg>
-      </div>
-
-    <div class="md-source__repository">
-      cloudfoundry/bosh
-    </div>
-  </a>
-
+    
+  </nav>
+  
+</header>
+    
+    <div class="md-container" data-md-component="container">
+         
+      {{ yield }}
+      
+      <footer class="md-footer">
+        <nav class="md-footer__inner md-grid" aria-label="Footer">
+          <a href="problems/" class="md-footer__link md-footer__link--next" aria-label="Next: Project Goals">
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                Next
+              </span>
+              <div class="md-ellipsis">
+                Project Goals
+              </div>
+            </div>
+            <div class="md-footer__button md-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 11v2h12l-5.5 5.5 1.42 1.42L19.84 12l-7.92-7.92L10.5 5.5 16 11z"/></svg>
+            </div>
+          </a>
+        </nav>
+        <div class="md-footer-meta md-typeset">
+          <div class="md-footer-meta__inner md-grid">
+            <div class="md-copyright">
+              
+              <div class="md-copyright__highlight">
+                powered by <a href="https://github.com/bosh-io/web" target="_blank" rel="noopener">bosh-io/web</a>, <a href="https://github.com/mkdocs/mkdocs" target="_blank" rel="noopener">mkdocs</a> and <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">material</a>
+              </div>
+            </div>
+            <div class="md-social">
+              <a href="https://github.com/cloudfoundry/bosh" target="_blank" rel="noopener" title="github.com" class="md-social__link">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M173.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6m-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3m44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9M252.8 8C114.1 8 8 113.3 8 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C436.2 457.8 504 362.9 504 252 504 113.3 391.5 8 252.8 8M105.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1m-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7m32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1m-11.4-14.7c-1.6 1-1.6 3.6 0 5.9s4.3 3.3 5.6 2.3c1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2"/></svg>
+              </a>
+              <a href="https://cloudfoundry.slack.com/messages/C02HPPYQ2/" target="_blank" rel="noopener" title="cloudfoundry.slack.com" class="md-social__link">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M94.1 315.1c0 25.9-21.2 47.1-47.1 47.1S0 341 0 315.1 21.2 268 47.1 268h47.1v47.1zm23.7 0c0-25.9 21.2-47.1 47.1-47.1s47.1 21.2 47.1 47.1v117.8c0 25.9-21.2 47.1-47.1 47.1s-47.1-21.2-47.1-47.1zm47.1-189c-25.9 0-47.1-21.2-47.1-47.1s21.2-47 47.1-47S212 53.2 212 79.1v47.1h-47.1zm0 23.7c25.9 0 47.1 21.2 47.1 47.1S190.8 244 164.9 244H47.1C21.2 244 0 222.8 0 196.9s21.2-47.1 47.1-47.1zm189 47.1c0-25.9 21.2-47.1 47.1-47.1s47 21.2 47 47.1-21.2 47.1-47.1 47.1h-47.1v-47.1zm-23.7 0c0 25.9-21.2 47.1-47.1 47.1S236 222.8 236 196.9V79.1c0-25.9 21.2-47.1 47.1-47.1s47.1 21.2 47.1 47.1zm-47.1 189c25.9 0 47.1 21.2 47.1 47.1s-21.2 47-47.1 47-47.1-21.2-47.1-47.1v-47.1h47.1zm0-23.7c-25.9 0-47.1-21.2-47.1-47.1s21.2-47.1 47.1-47.1h117.8c25.9 0 47.1 21.2 47.1 47.1s-21.2 47.1-47.1 47.1z"/></svg>
+              </a>
+              
+            </div>
+            
           </div>
         </div>
-
+      </footer>
+      
     </div>
-  </nav>
-</header>
-
-    <div class="md-container">
-
-
-
-
-
-
-
-
-
-
-  {{ yield }}
-  <footer class="md-footer">
-
-    <div class="md-footer-meta md-typeset">
-      <div class="md-footer-meta__inner md-grid">
-        <div class="md-footer-copyright">
-
-          powered by
-          <a href="https://github.com/bosh-io/web">bosh-io/web</a>,
-          <a href="https://github.com/mkdocs/mkdocs">mkdocs</a>,
-          and
-          <a href="https://github.com/squidfunk/mkdocs-material">material</a>
-        </div>
-
-
-    <div class="md-footer-social">
-
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-
-        <a href="https://github.com/cloudfoundry/bosh" class="md-footer-social__link fa fa-github"></a>
-
-        <a href="https://cloudfoundry.slack.com/messages/C02HPPYQ2/" class="md-footer-social__link fa fa-slack"></a>
-
+    <div class="md-dialog" data-md-component="dialog">
+      <div class="md-dialog__inner md-typeset"></div>
     </div>
-
-
-      </div>
-    </div>
-  </footer>
-
-      </div>
-
-        <script src="{{ themeJavascriptApplication }}"></script>
-
-        <script>app.initialize({version:"0.17.3",url:{base:"/docs"}})</script>
-
-    {{ template "shared/_google_analytics" }}
+    <script id="__config" type="application/json">{"annotate": null, "base": "/docs/", "features": ["content.action.edit", "content.code.copy", "navigation.tabs", "navigation.footer"], "search": "/docs/assets/javascripts/workers/search.2c215733.min.js", "tags": null, "translations": {"clipboard.copied": "Copied to clipboard", "clipboard.copy": "Copy to clipboard", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.placeholder": "Type to start searching", "search.result.term.missing": "Missing", "select.version": "Select version"}, "version": null}</script>
+    
+    <script src="/docs/assets/javascripts/bundle.79ae519e.min.js"></script>
   </body>
 </html>

--- a/templates/packages/_nav_secondary.tmpl
+++ b/templates/packages/_nav_secondary.tmpl
@@ -1,4 +1,4 @@
-<div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+<div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
   <div class="md-sidebar__scrollwrap">
     <div class="md-sidebar__inner">
       <nav class="md-nav md-nav--secondary">

--- a/templates/packages/show.tmpl
+++ b/templates/packages/show.tmpl
@@ -5,7 +5,7 @@
     {{ template "packages/_nav_secondary" . }}
     <div class="md-content">
       <article class="md-content__inner md-typeset">
-        <h1>{{ .Name }} package <small>from {{ .Release.Name }}/{{ .Release.Version }}</small></h1>
+        <h1 id="bosh-content-start">{{ .Name }} package <small>from {{ .Release.Name }}/{{ .Release.Version }}</small></h1>
 
         {{ if .HasGithubURL }}
           <p>

--- a/templates/packages/show.tmpl
+++ b/templates/packages/show.tmpl
@@ -1,5 +1,5 @@
 {{ template "shared/_nav_tabs" "Releases" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .Release.NavPrimary }}
     {{ template "packages/_nav_secondary" . }}

--- a/templates/releases/_usage.tmpl
+++ b/templates/releases/_usage.tmpl
@@ -1,7 +1,8 @@
 <p>You can reference this release in your deployment manifest from the <code>releases</code> section:</p>
 
 <div class="highlight">
-  <pre><span></span><code><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">{{ .Name }}</span>
+  <pre><span></span><code><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">name</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">{{ .Name }}</span>
+<span class="w">  </span><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="s">"{{ .Version }}"</span>
 <span class="w">  </span><span class="nt">url</span><span class="p">:</span><span class="w"> </span><span class="s">"<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</span>
 <span class="w">  </span><span class="nt">sha1</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">sha256:{{ .TarballSHA256 }}</span></code></pre>
 </div>
@@ -9,5 +10,6 @@
 <p>Or upload it to your director with the <code>upload-release</code> command:</p>
 
 <div class="highlight">
-  <pre><code>bosh<span class="w"> </span>upload-release<span class="w"> </span>"<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</code></pre>
+  <pre><code>bosh<span class="w"> </span>upload-release<span class="w"> </span>--sha1=sha256:{{ .TarballSHA256 }}<span class="w"> </span>\
+<span class="w">  </span>"<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</code></pre>
 </div>

--- a/templates/releases/_usage.tmpl
+++ b/templates/releases/_usage.tmpl
@@ -1,11 +1,13 @@
 <p>You can reference this release in your deployment manifest from the <code>releases</code> section:</p>
 
-<div class="codehilite"><pre>- name: "{{ .Name }}"
-  version: "{{ .Version }}"
-  url: "<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"
-  sha1: sha256:{{ .TarballSHA256 }}</pre></div>
+<div class="highlight">
+  <pre><span></span><code><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">{{ .Name }}</span>
+<span class="w">  </span><span class="nt">url</span><span class="p">:</span><span class="w"> </span><span class="s">"<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</span>
+<span class="w">  </span><span class="nt">sha1</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">sha256:{{ .TarballSHA256 }}</span></code></pre>
+</div>
 
 <p>Or upload it to your director with the <code>upload-release</code> command:</p>
 
-<div class="codehilite"><pre>bosh upload-release --sha1=sha256:{{ .TarballSHA256 }} \
-  "<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</pre></div>
+<div class="highlight">
+  <pre><code>bosh<span class="w"> </span>upload-release<span class="w"> </span>"<a href="{{ .UserVisibleDownloadURL }}" style="color:inherit;">{{ .UserVisibleDownloadURL }}</a>"</code></pre>
+</div>

--- a/templates/releases/graph.tmpl
+++ b/templates/releases/graph.tmpl
@@ -1,5 +1,5 @@
 {{ template "shared/_nav_tabs" "Releases" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .NavPrimary }}
     <div class="md-content">

--- a/templates/releases/graph.tmpl
+++ b/templates/releases/graph.tmpl
@@ -4,7 +4,7 @@
     {{ template "shared/_nav_primary" .NavPrimary }}
     <div class="md-content">
       <article class="md-content__inner md-typeset">
-        <h1>{{ .Name }}/{{ .Version }}</h1>
+        <h1 id="bosh-content-start">{{ .Name }}/{{ .Version }}</h1>
 
         <p>
           The following represents dependencies between jobs and packages. See below for more details.

--- a/templates/releases/index.tmpl
+++ b/templates/releases/index.tmpl
@@ -21,7 +21,7 @@
     </div>
     <div class="md-content">
       <article class="md-content__inner md-typeset">
-        <h1>Releases</h1>
+        <h1 id="bosh-content-start">Releases</h1>
 
         <p>A release is a versioned collection of configuration properties, configuration templates, start up scripts, source code, binary artifacts, and anything else required to build and deploy software in a reproducible way (<a href="/docs/release.html">learn more</a>).</p>
 

--- a/templates/releases/index.tmpl
+++ b/templates/releases/index.tmpl
@@ -1,8 +1,8 @@
 {{ template "shared/_nav_tabs" "Releases" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .NavPrimary }}
-    <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
       <div class="md-sidebar__scrollwrap">
         <div class="md-sidebar__inner">
           <nav class="md-nav md-nav--secondary">

--- a/templates/releases/show_version.tmpl
+++ b/templates/releases/show_version.tmpl
@@ -36,7 +36,7 @@
     </div>
     <div class="md-content">
       <article class="md-content__inner md-typeset">
-        <h1>{{ .Name }}/{{ .Version }}</h1>
+        <h1 id="bosh-content-start">{{ .Name }}/{{ .Version }}</h1>
 
         {{ if .HasGithubURL }}
           <p>

--- a/templates/releases/show_version.tmpl
+++ b/templates/releases/show_version.tmpl
@@ -1,8 +1,8 @@
 {{ template "shared/_nav_tabs" "Releases" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .NavPrimary }}
-    <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
       <div class="md-sidebar__scrollwrap">
         <div class="md-sidebar__inner">
           <nav class="md-nav md-nav--secondary">

--- a/templates/releases/show_versions.tmpl
+++ b/templates/releases/show_versions.tmpl
@@ -1,13 +1,13 @@
 {{ template "shared/_nav_tabs" "Releases" }}
 <main class="md-main" data-md-component="main">
-  <div class="md-main__inner md-grid">
+  <div class="md-main__inner md-grid" data-md-component="container">
     <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation">
       <div class="md-sidebar__scrollwrap">
         <div class="md-sidebar__inner">
-          <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation" aria-md-level="0">
+          <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation" data-md-level="0">
             <label class="md-nav__title" for="__drawer">
               <a href="." title="Cloud Foundry BOSH" class="md-nav__button md-logo" aria-label="Cloud Foundry BOSH" data-md-component="logo">
-                <img src="/docs/assets/images/logo.d93e7da69dbf.png" alt="logo">
+                <img src="{{ themeImageLogo }}" alt="logo">
               </a>
               Cloud Foundry BOSH
             </label>
@@ -107,7 +107,7 @@
     <div class="md-content">
       <article class="md-content__inner md-typeset">
         {{ if .Releases }}
-          <h1>{{ with index .Releases 0 }}{{ .Name }}{{ end }} Release</span></h1>
+          <h1 id="bosh-content-start">{{ with index .Releases 0 }}{{ .Name }}{{ end }} Release</span></h1>
         {{ else }}
           <h1>{{ .Source.Short }} Release</h1>
         {{ end }}

--- a/templates/releases/show_versions.tmpl
+++ b/templates/releases/show_versions.tmpl
@@ -1,14 +1,36 @@
 {{ template "shared/_nav_tabs" "Releases" }}
-<main class="md-main">
-  <div class="md-main__inner md-grid" data-md-component="container">
-    <div class="md-sidebar md-sidebar--primary" data-md-component="navigation">
+<main class="md-main" data-md-component="main">
+  <div class="md-main__inner md-grid">
+    <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation">
       <div class="md-sidebar__scrollwrap">
         <div class="md-sidebar__inner">
-          <nav class="md-nav md-nav--primary" data-md-level="0">
+          <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation" aria-md-level="0">
+            <label class="md-nav__title" for="__drawer">
+              <a href="." title="Cloud Foundry BOSH" class="md-nav__button md-logo" aria-label="Cloud Foundry BOSH" data-md-component="logo">
+                <img src="/docs/assets/images/logo.d93e7da69dbf.png" alt="logo">
+              </a>
+              Cloud Foundry BOSH
+            </label>
+            <div class="md-nav__source">
+              <a href="https://github.com/cloudfoundry/bosh" title="Go to repository" class="md-source" data-md-component="source">
+                <div class="md-source__icon md-icon">                    
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M439.6 236.1 244 40.5c-5.4-5.5-12.8-8.5-20.4-8.5s-15 3-20.4 8.4L162.5 81l51.5 51.5c27.1-9.1 52.7 16.8 43.4 43.7l49.7 49.7c34.2-11.8 61.2 31 35.5 56.7-26.5 26.5-70.2-2.9-56-37.3L240.3 199v121.9c25.3 12.5 22.3 41.8 9.1 55-6.4 6.4-15.2 10.1-24.3 10.1s-17.8-3.6-24.3-10.1c-17.6-17.6-11.1-46.9 11.2-56v-123c-20.8-8.5-24.6-30.7-18.6-45L142.6 101 8.5 235.1C3 240.6 0 247.9 0 255.5s3 15 8.5 20.4l195.6 195.7c5.4 5.4 12.7 8.4 20.4 8.4s15-3 20.4-8.4l194.7-194.7c5.4-5.4 8.4-12.8 8.4-20.4s-3-15-8.4-20.4"></path></svg>
+                </div>
+                <div class="md-source__repository">
+                  cloudfoundry/bosh
+                </div>
+              </a>
+            </div>
             <ul class="md-nav__list" data-md-scrollfix>
-              <li class="md-nav__item md-nav__item--active md-nav__item--nested">
-                <nav class="md-nav" data-md-component="collapsible" data-md-level="1">
-                  <label class="md-nav__title">
+              <li class="md-nav__item md-nav__item--section md-nav__item--bosh-persistent md-nav__item--nested">
+                <input class="md-nav__toggle md-toggle " type="checkbox" id="__nav_1">
+                <label class="md-nav__link" for="__nav_1" id="__nav_1_label" tabindex="">
+                  <span class="md-ellipsis">Releases</span>
+                  <span class="md-nav__icon md-icon"></span>
+                </label>
+                <nav class="md-nav" data-md-level="1" aria-labelledby="__nav_1_label" aria-expanded="true">
+                  <label class="md-nav__title" for="__nav_1">
+                    <span class="md-nav__icon md-icon"></span>
                     Releases
                   </label>
                   <ul class="md-nav__list" data-md-scrollfix>
@@ -20,10 +42,22 @@
                   </ul>
                 </nav>
               </li>
-              <li class="md-nav__item md-nav__item--active md-nav__item--nested">
-                <nav class="md-nav" data-md-component="collapsible" data-md-level="1">
-                  <label class="md-nav__title">
-                    <br>
+              
+              <li class="md-nav__item md-nav__item--active md-nav__item--section md-nav__item--nested">
+                <input class="md-nav__toggle md-toggle " type="checkbox" id="__nav_2" checked="">
+                <label class="md-nav__link" for="__nav_2" id="__nav_2_label" tabindex="">
+                  <span class="md-ellipsis">
+                    {{ if .Releases }}
+                      {{ with index .Releases 0 }}{{ .Name }}{{ end }}
+                    {{ else }}
+                      {{ .Source.Short }}
+                    {{ end }}
+                  </span>
+                  <span class="md-nav__icon md-icon"></span>
+                </label>
+                <nav class="md-nav" data-md-level="1" aria-labelledby="__nav_2_label">
+                  <label class="md-nav__title" for="__nav_2">
+                    <span class="md-nav__icon md-icon"></span>
                     {{ if .Releases }}
                       {{ with index .Releases 0 }}{{ .Name }}{{ end }}
                     {{ else }}
@@ -31,19 +65,26 @@
                     {{ end }}
                   </label>
                   <ul class="md-nav__list" data-md-scrollfix>
-                    <li class="md-nav__item md-nav__item--active">
-                      <a href="{{ .URL }}" title="All Versions" class="md-nav__link md-nav__link--active">All Versions</a>
-                    </li>
+                    <li class="md-nav__item">
+                      <a href="{{ .URL }}" title="All Versions" class="md-nav__link md-nav__link--active">
+                        All Versions
+                      </a>
                     </li>
                   </ul>
                 </nav>
+              </li>
+
+              <li class="md-nav__item md-nav__item--bosh-sidebar-sticky-bottom">
+                <a href="/docs/" class="md-nav__link">
+                  Back to Docs
+                </a>
               </li>
             </ul>
           </nav>
         </div>
       </div>
     </div>
-    <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
       <div class="md-sidebar__scrollwrap">
         <div class="md-sidebar__inner">
           <nav class="md-nav md-nav--secondary">

--- a/templates/shared/_nav_item.tmpl
+++ b/templates/shared/_nav_item.tmpl
@@ -2,7 +2,8 @@
   <li class="md-nav__item{{ if .Active }} md-nav__item--active{{ end }}{{ if .IsSection }} md-nav__item--section{{ end }}{{ if .IsPersistent }} md-nav__item--bosh-persistent{{ end }} md-nav__item--nested">
     <input class="md-toggle md-nav__toggle" data-md-toggle="{{ .Ref }}" type="checkbox" id="{{ .Ref }}"{{ if .Active }} checked{{ end }} />
     <label class="md-nav__link" for="{{ .Ref }}">
-      {{ .Title }}
+      <span class="md-ellipsis">{{ .Title }}</span>
+      <span class="md-nav__icon md-icon"></span>
     </label>
     <nav class="md-nav" data-md-component="collapsible" data-md-level="{{ .Depth }}">
       <label class="md-nav__title" for="{{ .Ref }}">

--- a/templates/shared/_nav_item.tmpl
+++ b/templates/shared/_nav_item.tmpl
@@ -1,12 +1,12 @@
 {{ if .Children }}
-  <li class="md-nav__item{{ if .Active }} md-nav__item--active{{ end }} md-nav__item--nested">
+  <li class="md-nav__item{{ if .Active }} md-nav__item--active{{ end }}{{ if .IsSection }} md-nav__item--section{{ end }}{{ if .IsPersistent }} md-nav__item--bosh-persistent{{ end }} md-nav__item--nested">
     <input class="md-toggle md-nav__toggle" data-md-toggle="{{ .Ref }}" type="checkbox" id="{{ .Ref }}"{{ if .Active }} checked{{ end }} />
     <label class="md-nav__link" for="{{ .Ref }}">
       {{ .Title }}
     </label>
     <nav class="md-nav" data-md-component="collapsible" data-md-level="{{ .Depth }}">
       <label class="md-nav__title" for="{{ .Ref }}">
-        {{ if gt .Index 0 }}<br>{{ end }}
+        <span class="md-nav__icon md-icon"></span>
         {{ .Title }}
       </label>
       <ul class="md-nav__list" data-md-scrollfix>

--- a/templates/shared/_nav_primary.tmpl
+++ b/templates/shared/_nav_primary.tmpl
@@ -1,11 +1,7 @@
-<style>
-
-</style>
-
 <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation">
   <div class="md-sidebar__scrollwrap">
     <div class="md-sidebar__inner">
-      <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation" aria-md-level="0">
+      <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation" data-md-level="0">
         <label class="md-nav__title" for="__drawer">
           <a href="." title="Cloud Foundry BOSH" class="md-nav__button md-logo" aria-label="Cloud Foundry BOSH" data-md-component="logo">
             <img src="{{ themeImageLogo }}" alt="logo">

--- a/templates/shared/_nav_primary.tmpl
+++ b/templates/shared/_nav_primary.tmpl
@@ -1,29 +1,36 @@
-<div class="md-sidebar md-sidebar--primary" data-md-component="navigation">
+<style>
+
+</style>
+
+<div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation">
   <div class="md-sidebar__scrollwrap">
     <div class="md-sidebar__inner">
-      <nav class="md-nav md-nav--primary" data-md-level="0">
-        <label class="md-nav__title md-nav__title--site" for="drawer">
-          <span class="md-nav__button md-logo">
-            <img src="{{ themeImageLogo }}" width="48" height="48">
-          </span>
+      <nav class="md-nav md-nav--primary md-nav--lifted" aria-label="Navigation" aria-md-level="0">
+        <label class="md-nav__title" for="__drawer">
+          <a href="." title="Cloud Foundry BOSH" class="md-nav__button md-logo" aria-label="Cloud Foundry BOSH" data-md-component="logo">
+            <img src="{{ themeImageLogo }}" alt="logo">
+          </a>
           Cloud Foundry BOSH
         </label>
         <div class="md-nav__source">
-          <a href="https://github.com/cloudfoundry/docs-bosh/" title="Go to repository" class="md-source" data-md-source="github" data-md-state="done">
-            <div class="md-source__icon">
-              <svg viewBox="0 0 24 24" width="24" height="24">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#github" width="24" height="24"></use>
-              </svg>
+          <a href="https://github.com/cloudfoundry/bosh" title="Go to repository" class="md-source" data-md-component="source">
+            <div class="md-source__icon md-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M439.6 236.1 244 40.5c-5.4-5.5-12.8-8.5-20.4-8.5s-15 3-20.4 8.4L162.5 81l51.5 51.5c27.1-9.1 52.7 16.8 43.4 43.7l49.7 49.7c34.2-11.8 61.2 31 35.5 56.7-26.5 26.5-70.2-2.9-56-37.3L240.3 199v121.9c25.3 12.5 22.3 41.8 9.1 55-6.4 6.4-15.2 10.1-24.3 10.1s-17.8-3.6-24.3-10.1c-17.6-17.6-11.1-46.9 11.2-56v-123c-20.8-8.5-24.6-30.7-18.6-45L142.6 101 8.5 235.1C3 240.6 0 247.9 0 255.5s3 15 8.5 20.4l195.6 195.7c5.4 5.4 12.7 8.4 20.4 8.4s15-3 20.4-8.4l194.7-194.7c5.4-5.4 8.4-12.8 8.4-20.4s-3-15-8.4-20.4"></path></svg>
             </div>
             <div class="md-source__repository">
-              cloudfoundry/docs-bosh
-            <ul class="md-source__facts"><li class="md-source__fact">28 Stars</li><li class="md-source__fact">202 Forks</li></ul></div>
+              cloudfoundry/bosh
+            </div>
           </a>
         </div>
         <ul class="md-nav__list" data-md-scrollfix>
-          {{ range .Children }}
-            {{ template "shared/_nav_item" . }}
-          {{ end }}
+        {{ range .Children }}
+          {{ template "shared/_nav_item" . }}
+        {{ end }}
+          <li class="md-nav__item md-nav__item--bosh-sidebar-sticky-bottom">
+            <a href="/docs/" class="md-nav__link">
+              Back to Docs
+            </a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/templates/shared/_nav_tabs.tmpl
+++ b/templates/shared/_nav_tabs.tmpl
@@ -1,12 +1,36 @@
-<nav class="md-tabs md-tabs--active" data-md-component="tabs">
-  <div class="md-tabs__inner md-grid">
+<nav class="md-tabs" aria-label="Tabs" data-md-component="tabs">
+  <div class="md-grid">
     <ul class="md-tabs__list">
-      <li class="md-tabs__item"><a href="/docs/" title="About" class="md-tabs__link">About</a></li>
-      <li class="md-tabs__item"><a href="/docs/cli-v2-install/" title="Installation" class="md-tabs__link">Installation</a></li>
-      <li class="md-tabs__item"><a href="/docs/update-cloud-config/" title="Guides" class="md-tabs__link">Guides</a></li>
-      <li class="md-tabs__item"><a href="/docs/terminology/" title="Reference" class="md-tabs__link">Reference</a></li>
-      <li class="md-tabs__item"><a href="/stemcells/" title="Stemcells" class="md-tabs__link{{ if eq . "Stemcells" }} md-tabs__link--active{{ end }}">Stemcells</a></li>
-      <li class="md-tabs__item"><a href="/releases/" title="Releases" class="md-tabs__link{{ if eq . "Releases" }} md-tabs__link--active{{ end }}">Releases</a></li>
+      <li class="md-tabs__item">
+        <a href="/docs/" class="md-tabs__link">
+          About
+        </a>
+      </li>
+      <li class="md-tabs__item">
+        <a href="/docs/cli-v2-install/" class="md-tabs__link">
+          Installation
+        </a>
+      </li>
+      <li class="md-tabs__item">
+        <a href="/docs/update-cloud-config/" class="md-tabs__link">
+          Guides
+        </a>
+      </li>
+      <li class="md-tabs__item">
+        <a href="/docs/terminology/" class="md-tabs__link">
+          Reference
+        </a>
+      </li>
+      <li class="md-tabs__item{{ if eq . "Stemcells" }} md-tabs__item--active{{ end }}">
+        <a href="/stemcells/" class="md-tabs__link">
+          Stemcells
+        </a>
+      </li>
+      <li class="md-tabs__item{{ if eq . "Releases" }} md-tabs__item--active{{ end }}">
+        <a href="/releases/" class="md-tabs__link">
+          Releases
+        </a>
+      </li>
     </ul>
   </div>
 </nav>

--- a/templates/stemcells/all.tmpl
+++ b/templates/stemcells/all.tmpl
@@ -20,7 +20,7 @@
     </div>
     <div class="md-content">
       <article class="md-content__inner md-typeset">
-        <h1>Stemcells</h1>
+        <h1 id="bosh-content-start">Stemcells</h1>
 
         {{ template "stemcells/_defined" . }}
 

--- a/templates/stemcells/all.tmpl
+++ b/templates/stemcells/all.tmpl
@@ -1,8 +1,8 @@
 {{ template "shared/_nav_tabs" "Stemcells" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .NavPrimary }}
-    <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
       <div class="md-sidebar__scrollwrap">
         <div class="md-sidebar__inner">
           <nav class="md-nav md-nav--secondary">

--- a/templates/stemcells/single.tmpl
+++ b/templates/stemcells/single.tmpl
@@ -1,8 +1,8 @@
 {{ template "shared/_nav_tabs" "Stemcells" }}
-<main class="md-main">
+<main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .NavPrimary }}
-    <div class="md-sidebar md-sidebar--secondary" data-md-component="toc"></div>
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc"></div>
     <div class="md-content">{{ $s := .DistroGroups.FirstStemcell }}
       <article class="md-content__inner md-typeset">
         <h1>{{ .Filter.Name }}</h1>
@@ -18,15 +18,17 @@
 
         <p>You can upload the latest version to your director with the <code>upload-stemcell</code> command:</p>
 
-        <div class="codehilite"><pre>bosh upload-stemcell --sha1 {{ $s.SHA1 }} \
-  "<a href="{{ $s.UserVisibleDownloadURL }}" style="color:inherit;">{{ $s.UserVisibleDownloadURL }}</a>"</pre></div>
+        <div class="highlight">
+          <pre><span></span><code>bosh upload-stemcell --sha1 {{ $s.SHA1 }} \
+  "<a href="{{ $s.UserVisibleDownloadURL }}" style="color:inherit;">{{ $s.UserVisibleDownloadURL }}</a>"</code></pre>
+        </div>
 
         <p>And reference this stemcell in your deployment manifest from the <code>stemcells</code> section:</p>
-
-        <div class="codehilite"><pre>- alias: "default"
-  os: "{{ $s.OSName }}{{ if ( ne $s.OSName "windows" ) }}-{{ end }}{{ $s.OSVersion }}"
-  version: "{{ $s.Version }}"
-</pre></div>
+        <div class="highlight">
+          <pre><span></span><code><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">alias</span><span class="p">:</span><span class="w"> </span><span class="s">"default"</span>
+<span class="w">  </span><span class="nt">os</span><span class="p">:</span><span class="w"> </span><span class="s">"{{ $s.OSName }}{{ if ( ne $s.OSName "windows" ) }}-{{ end }}{{ $s.OSVersion }}"</span>
+<span class="w">  </span><span class="nt">sha1</span><span class="p">:</span><span class="w"> </span><span class="s">"{{ $s.Version }}"</span></code></pre>
+        </div>
 
         {{ if (eq $s.OSName "windows") }}
           {{ template "stemcells/_windows_notice" . }}
@@ -52,7 +54,7 @@
                       <a href="{{ .UserVisibleDownloadURL }}" title="{{ .FormattedSize }}">{{ .LinkName }}</a>
                       {{ if .SHA1 }}
                         &ndash;
-                        <code class="codehilite">sha1:{{ .SHA1 }}</code>
+                        <code class="highlight">sha1:{{ .SHA1 }}</code>
                       {{ end }}
                     </li>
                   {{ end }}

--- a/templates/stemcells/single.tmpl
+++ b/templates/stemcells/single.tmpl
@@ -2,7 +2,13 @@
 <main class="md-main" data-md-component="main">
   <div class="md-main__inner md-grid" data-md-component="container">
     {{ template "shared/_nav_primary" .NavPrimary }}
-    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc"></div>
+    <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc">
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          <nav class="md-nav md-nav--secondary"></nav>
+        </div>
+      </div>
+    </div>
     <div class="md-content">{{ $s := .DistroGroups.FirstStemcell }}
       <article class="md-content__inner md-typeset">
         <h1 id="bosh-content-start">{{ .Filter.Name }}</h1>

--- a/templates/stemcells/single.tmpl
+++ b/templates/stemcells/single.tmpl
@@ -5,7 +5,7 @@
     <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc"></div>
     <div class="md-content">{{ $s := .DistroGroups.FirstStemcell }}
       <article class="md-content__inner md-typeset">
-        <h1>{{ .Filter.Name }}</h1>
+        <h1 id="bosh-content-start">{{ .Filter.Name }}</h1>
 
           {{ if (eq $s.OSVersion "jammy") }}
             {{ template "stemcells/_jammy_notice" . }}
@@ -27,7 +27,7 @@
         <div class="highlight">
           <pre><span></span><code><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">alias</span><span class="p">:</span><span class="w"> </span><span class="s">"default"</span>
 <span class="w">  </span><span class="nt">os</span><span class="p">:</span><span class="w"> </span><span class="s">"{{ $s.OSName }}{{ if ( ne $s.OSName "windows" ) }}-{{ end }}{{ $s.OSVersion }}"</span>
-<span class="w">  </span><span class="nt">sha1</span><span class="p">:</span><span class="w"> </span><span class="s">"{{ $s.Version }}"</span></code></pre>
+<span class="w">  </span><span class="nt">version</span><span class="p">:</span><span class="w"> </span><span class="s">"{{ $s.Version }}"</span></code></pre>
         </div>
 
         {{ if (eq $s.OSName "windows") }}

--- a/ui/nav/link.go
+++ b/ui/nav/link.go
@@ -3,10 +3,10 @@ package nav
 import "fmt"
 
 type Link struct {
-	Title string
-	URL   string
+	Title        string
+	URL          string
 	IsPersistent bool
-	IsSection  bool
+	IsSection    bool
 
 	idx      int
 	active   bool
@@ -16,12 +16,12 @@ type Link struct {
 
 func (l *Link) Add(link Link) *Link {
 	nl := Link{
-		Title:  link.Title,
-		URL:    link.URL,
+		Title:        link.Title,
+		URL:          link.URL,
 		IsPersistent: link.IsPersistent,
-		IsSection: link.IsSection,
-		parent: l,
-		idx:    len(l.children),
+		IsSection:    link.IsSection,
+		parent:       l,
+		idx:          len(l.children),
 	}
 
 	for _, cl := range link.Children() {

--- a/ui/nav/link.go
+++ b/ui/nav/link.go
@@ -5,6 +5,8 @@ import "fmt"
 type Link struct {
 	Title string
 	URL   string
+	IsPersistent bool
+	IsSection  bool
 
 	idx      int
 	active   bool
@@ -16,6 +18,8 @@ func (l *Link) Add(link Link) *Link {
 	nl := Link{
 		Title:  link.Title,
 		URL:    link.URL,
+		IsPersistent: link.IsPersistent,
+		IsSection: link.IsSection,
 		parent: l,
 		idx:    len(l.children),
 	}

--- a/ui/release/nav.go
+++ b/ui/release/nav.go
@@ -5,13 +5,12 @@ import "github.com/bosh-io/web/ui/nav"
 func Navigation() nav.Link {
 	root := nav.Link{Title: "Releases"}
 
-	allnav := nav.Link{Title: "Releases", URL: "#releases"}
+	allnav := nav.Link{Title: "Releases", URL: "#releases", IsSection: true}
 	allnav.Add(nav.Link{
 		Title: "Browse Releases",
 		URL:   "/releases",
 	})
 	root.Add(allnav)
-	root.Activate("#releases")
 
 	return root
 }

--- a/ui/release/release.go
+++ b/ui/release/release.go
@@ -88,7 +88,7 @@ func NewIncompleteRelease(relVerRec bhrelsrepo.ReleaseVersionRec, name string) R
 func (r Release) BuildNavigation(active string) nav.Link {
 	root := Navigation()
 
-	relnav := nav.Link{Title: r.Name}
+	relnav := nav.Link{Title: r.Name, IsSection: true}
 	relnav.Add(nav.Link{
 		Title: "All Versions",
 		URL:   r.AllVersionsURL(),

--- a/ui/stemcell/nav.go
+++ b/ui/stemcell/nav.go
@@ -9,7 +9,11 @@ import (
 func Navigation() nav.Link {
 	root := nav.Link{Title: "Stemcells"}
 
-	allnav := nav.Link{Title: "Stemcells", URL: "#stemcells"}
+	allnav := nav.Link{
+		Title: "Stemcells",
+		URL: "#stemcells",
+		IsSection: true,
+	}
 	allnav.Add(nav.Link{
 		Title: "Latest Versions",
 		URL:   "/stemcells",

--- a/ui/stemcell/nav.go
+++ b/ui/stemcell/nav.go
@@ -10,8 +10,8 @@ func Navigation() nav.Link {
 	root := nav.Link{Title: "Stemcells"}
 
 	allnav := nav.Link{
-		Title: "Stemcells",
-		URL: "#stemcells",
+		Title:     "Stemcells",
+		URL:       "#stemcells",
 		IsSection: true,
 	}
 	allnav.Add(nav.Link{


### PR DESCRIPTION
> [!NOTE]
> This must be merged in tandem with https://github.com/cloudfoundry/docs-bosh/pull/908 to prevent a broken website deploy.

~**Update:**~

~I realise we need to update the templates within the repo as well, otherwise the launching the web server fails.
I'm working on these changes. Pending that, this PR should not be merged as-is.~

**Update 2:**

The template have been updated.

Since we're here, I've also applied some fixes and minor enhancements:
- Fixed several issues with the mobile sidebar on pages with the pseudo-section hack
- Added `Back to Docs` at bottom of mobile sidebar