### PR TITLE
test: fix broken smoke tests

### DIFF
--- a/bin/test-server
+++ b/bin/test-server
@@ -18,8 +18,8 @@ if curl --fail -s  "$server/docs/terminology/" | grep 'Pivotal Tracker' >/dev/nu
   exit 1
 fi
 
-if ! curl --fail -s  "$server/docs/community/" | grep 'Pivotal Tracker' >/dev/null ; then
-  echo "FAILURE: expected to see 'Pivotal Tracker' on the /docs/community/ page" >&2
+if ! curl --fail -s  "$server/docs/community/" | grep -z 'GitHub\sProjects' >/dev/null ; then
+  echo "FAILURE: expected to see 'GitHub Projects' on the /docs/community/ page" >&2
 
   exit 1
 fi


### PR DESCRIPTION
Updated test's search string to match updated BOSH docs.

Tested the test's before-and-after, and verified it's original failure and that it now works on my local machine.

see: https://github.com/cloudfoundry/docs-bosh/pull/906#issuecomment-4869495512y